### PR TITLE
Fix [core/instance] Cullin_of_Strasolme Chromie give player wrong item repeatly

### DIFF
--- a/src/server/game/Spells/SpellMgr.cpp
+++ b/src/server/game/Spells/SpellMgr.cpp
@@ -7474,7 +7474,7 @@ void SpellMgr::LoadDbcDataCorrections()
         spellInfo->ProcChance = 101;
         spellInfo->Effect[1] = 24;
         spellInfo->EffectImplicitTargetA[1] = 25;
-        spellInfo->EffectItemType[1] = 37889;
+        spellInfo->EffectItemType[1] = 37888;
     });
 
     // Serverside - Create Rocket Pack

--- a/src/server/scripts/Kalimdor/CavernsOfTime/CullingOfStratholme/culling_of_stratholme.cpp
+++ b/src/server/scripts/Kalimdor/CavernsOfTime/CullingOfStratholme/culling_of_stratholme.cpp
@@ -1444,7 +1444,7 @@ public:
 
                 if (!player->HasItemCount(ITEM_ARCANE_DISRUPTOR))
                 {
-                    player->AddItem(ITEM_ARCANE_DISRUPTOR, 1);
+                    me->CastSpell(player, SPELL_SUMMON_ARCANE_DISRUPTOR);
                 }
             }
             // Skip Event

--- a/src/server/scripts/Kalimdor/CavernsOfTime/CullingOfStratholme/culling_of_stratholme.cpp
+++ b/src/server/scripts/Kalimdor/CavernsOfTime/CullingOfStratholme/culling_of_stratholme.cpp
@@ -1444,7 +1444,7 @@ public:
 
                 if (!player->HasItemCount(ITEM_ARCANE_DISRUPTOR))
                 {
-                    me->CastSpell(player, SPELL_SUMMON_ARCANE_DISRUPTOR);
+                    player->AddItem(ITEM_ARCANE_DISRUPTOR, 1);
                 }
             }
             // Skip Event


### PR DESCRIPTION
Fix Chromie add wrong item 37889 to player cause of cast a wrong spell

<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  as title
-  

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes 

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
Tested


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1.make a chracters that has finish Quest 13149
2.Tele to Culling_of_Stratholme
3.speak to chromie
3.see if she give you item 37888 but not repeatly 37889

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
